### PR TITLE
isobmff: Fix box size 0 parsing

### DIFF
--- a/src/box_reader_impl.h
+++ b/src/box_reader_impl.h
@@ -43,7 +43,8 @@ struct BoxReader : IReader
     }
     else if(size == 0)
     {
-      size = myBox.size + boxHeaderSize - br.m_pos / 8; // until the end of container - may be impossible to get right in some wrong cases
+      // until the end of container - may be impossible to get right in some wrong cases
+      size = subReader.myBox.size = myBox.size + boxHeaderSize - br.m_pos / 8;
     }
 
     ENSURE(size >= boxHeaderSize, "BoxReader::box(): box size %llu < %u bytes (fourcc='%s')",

--- a/tests/avif/valid-64b-box-size-0-box-size.asm
+++ b/tests/avif/valid-64b-box-size-0-box-size.asm
@@ -1,0 +1,143 @@
+%define BE(a) ( ((((a)>>24)&0xFF) << 0) + ((((a)>>16)&0xFF) << 8) + ((((a)>>8)&0xFF) << 16)  + ((((a)>>0)&0xFF) << 24))
+
+ftyp_start:
+    dd BE(ftyp_end - ftyp_start)
+    dd "ftyp"
+    db 0x61, 0x76, 0x69, 0x66 ; brand(32) ('avif') 
+    db 0x00, 0x00, 0x00, 0x00 ; version(32) 
+    db 0x61, 0x76, 0x69, 0x66 ; compatible_brand(32) ('avif') 
+    db 0x6D, 0x69, 0x66, 0x31 ; compatible_brand(32) ('mif1') 
+    db 0x6D, 0x69, 0x61, 0x66 ; compatible_brand(32) ('miaf') 
+    db 0x4D, 0x41, 0x31, 0x42 ; compatible_brand(32) ('MA1B') 
+ftyp_end:
+meta_start:
+    db 0x00, 0x00, 0x00, 0x01 ; size(32) 
+    dd "meta"
+    db 0x00, 0x00, 0x00, 0x00 ; largesize(32) 
+    dd BE(meta_end - meta_start)
+    db 0x00 ; version(8) 
+    db 0x00, 0x00, 0x00 ; flags(24) 
+    hdlr_start:
+        dd BE(hdlr_end - hdlr_start)
+        dd "hdlr"
+        db 0x00 ; version(8) 
+        db 0x00, 0x00, 0x00 ; flags(24) 
+        db 0x00, 0x00, 0x00, 0x00 ; pre_defined(32) 
+        db 0x70, 0x69, 0x63, 0x74 ; handler_type(32) ('pict') 
+        db 0x00, 0x00, 0x00, 0x00 ; reserved1(32) 
+        db 0x00, 0x00, 0x00, 0x00 ; reserved2(32) 
+        db 0x00, 0x00, 0x00, 0x00 ; reserved3(32) 
+        db 0x00 ; name(8) 
+    hdlr_end:
+    iloc_start:
+        dd BE(iloc_end - iloc_start)
+        dd "iloc"
+        db 0x00 ; version(8) 
+        db 0x00, 0x00, 0x00 ; flags(24) 
+        db 0x04 ; offset_size(4) length_size(4) 
+        db 0x40 ; base_offset_size(4) ('@') reserved1(4) ('@') 
+        db 0x00, 0x01 ; item_count(16) 
+        db 0x00, 0x01 ; item_ID(16) 
+        db 0x00, 0x00 ; data_reference_index(16) 
+        db 0x00, 0x00, 0x01, 0x15 ; base_offset(32) 
+        db 0x00, 0x01 ; extent_count(16) 
+         ; extent_offset(0) 
+        db 0x00, 0x00, 0x00, 0x0B ; base_offset(32) 
+    iloc_end:
+    iinf_start:
+        dd BE(iinf_end - iinf_start)
+        dd "iinf"
+        db 0x01 ; version(8) 
+        db 0x00, 0x00, 0x00 ; flags(24) 
+        db 0x00, 0x00, 0x00, 0x01 ; entry_count(32) 
+        infe_start:
+            dd BE(infe_end - infe_start)
+            dd "infe"
+            db 0x02 ; version(8) 
+            db 0x00, 0x00, 0x00 ; flags(24) 
+            db 0x00, 0x01 ; item_ID(16) 
+            db 0x00, 0x00 ; item_protection_index(16) 
+            db 0x61, 0x76, 0x30, 0x31 ; item_type(32) ('av01') 
+            db 0x00 ; item_name(8) 
+        infe_end:
+    iinf_end:
+    pitm_start:
+        dd BE(pitm_end - pitm_start)
+        dd "pitm"
+        db 0x00 ; version(8) 
+        db 0x00, 0x00, 0x00 ; flags(24) 
+        db 0x00, 0x01 ; item_ID(16) 
+    pitm_end:
+    iprp_start:
+        dd BE(iprp_end - iprp_start)
+        dd "iprp"
+        ipco_start:
+            dd BE(ipco_end - ipco_start)
+            dd "ipco"
+            pasp_start:
+                dd BE(pasp_end - pasp_start)
+                dd "pasp"
+                db 0x00, 0x00, 0x00, 0x01 ; hSpacing(32) 
+                db 0x00, 0x00, 0x00, 0x01 ; vSpacing(32) 
+            pasp_end:
+            ispe_start:
+                dd BE(ispe_end - ispe_start)
+                dd "ispe"
+                db 0x00 ; version(8) 
+                db 0x00, 0x00, 0x00 ; flags(24) 
+                db 0x00, 0x00, 0x04, 0xB4 ; image_width(32) 
+                db 0x00, 0x00, 0x03, 0x20 ; image_height(32) 
+            ispe_end:
+            pixi_start:
+                dd BE(pixi_end - pixi_start)
+                dd "pixi"
+                db 0x00 ; (8) 
+                db 0x00 ; (8) 
+                db 0x00 ; (8) 
+                db 0x00 ; (8) 
+                db 0x03 ; (8) 
+                db 0x08 ; (8) 
+                db 0x08 ; (8) 
+                db 0x08 ; (8) 
+            pixi_end:
+            av1C_start:
+                dd BE(av1C_end - av1C_start)
+                dd "av1C"
+                db 0x81 ; marker(1) version(7) 
+                db 0x05 ; seq_profile(3) seq_level_idx_0(5) 
+                db 0x0C ; seq_tier_0(1) high_bitdepth(1) twelve_bit(1) monochrome(1) chroma_subsampling_x(1) chroma_subsampling_y(1) chroma_sample_position(2) 
+                db 0x00 ; reserved(3) initial_presentation_delay_present(1) reserved(4) 
+            av1C_end:
+        ipco_end:
+        ipma_start:
+            dd BE(ipma_end - ipma_start)
+            dd "ipma"
+            db 0x00 ; version(8) 
+            db 0x00, 0x00, 0x00 ; flags(24) 
+            db 0x00, 0x00, 0x00, 0x01 ; entry_count(32) 
+            db 0x00, 0x01 ; item_ID(16) 
+            db 0x04 ; association_count(8) 
+            db 0x01 ; essential(1) property_index(7) 
+            db 0x02 ; essential(1) property_index(7) 
+            db 0x83 ; essential(1) property_index(7) 
+            db 0x84 ; essential(1) property_index(7) 
+        ipma_end:
+    iprp_end:
+meta_end:
+mdat_start:
+    db 0x00, 0x00, 0x00, 0x00 ; size(32) 
+    dd "mdat"
+    db 0x0A ; (8) 
+    db 0x07 ; (8) 
+    db 0x19 ; (8) 
+    db 0x6A ; (8) ('j') 
+    db 0x65 ; (8) ('e') 
+    db 0x9E ; (8) 
+    db 0x3F ; (8) ('?') 
+    db 0xC8 ; (8) 
+    db 0x04 ; (8) 
+    db 0x32 ; (8) ('2') 
+    db 0x00 ; (8) 
+mdat_end:
+
+; vim: syntax=nasm

--- a/tests/avif/valid-64b-box-size-0-box-size.ref
+++ b/tests/avif/valid-64b-box-size-0-box-size.ref
@@ -1,0 +1,43 @@
++--------------------------------------+
+|           avif validation            |
++--------------------------------------+
+
+Specification description: AVIF v1.0.0, 19 February 2019
+https://aomediacodec.github.io/av1-avif/
+
+========================================
+[avif] No errors.
+========================================
+
++--------------------------------------+
+|           miaf validation            |
++--------------------------------------+
+
+Specification description: MIAF (Multi-Image Application Format)
+MPEG-A part 22 - ISO/IEC 23000-22 - w18260 FDIS - Jan 2019
+
+========================================
+[miaf] No errors.
+========================================
+
++--------------------------------------+
+|           heif validation            |
++--------------------------------------+
+
+Specification description: HEIF - ISO/IEC 23008-12 - 2nd Edition N18310
+
+========================================
+[heif] No errors.
+========================================
+
++--------------------------------------+
+|          isobmff validation          |
++--------------------------------------+
+
+Specification description: ISO Base Media File Format
+MPEG-4 part 12 - ISO/IEC 14496-12 - m17277 (6th+FDAM1+FDAM2+COR1-R4)
+
+========================================
+[isobmff] No errors.
+========================================
+


### PR DESCRIPTION
Add a test exercizing the parsing of boxes of sizes 0 (till the end
of the file) and 1 (stored as 64b largesize after box type).
tests/avif/valid-64b-box-size-0-box-size.asm is tests/avif/valid.asm
with the following changes:
- "meta" size is 0x1 and its largesize is the size of the box
- "iloc" base_offset is updated (+8 bytes)
- "mdat" size is 0x0

Note: without the fix, cw outputs the following when "mdat" size is 0:
```
[miaf][Rule #7] Error: Item bodies of coded image "av01" itemID=1 (offset=277) belongs to box "root": expecting "mdat"
[isobmff][Rule #1] Error: Data offset 277 belongs to box "root": expecting "mdat" or "idat"
```