### PR TITLE
Cast sym.value to uint32_t when inserting to itemRefs

### DIFF
--- a/src/utils/isobmff_derivations.cpp
+++ b/src/utils/isobmff_derivations.cpp
@@ -182,7 +182,7 @@ Derivations getDerivationsInfo(Box const& root, uint32_t irefTypeFourcc)
 
                 if(it == d.itemRefs.end())
                 {
-                  d.itemRefs.insert({ sym.value, {}
+                  d.itemRefs.insert({ (uint32_t)sym.value, {}
                                     });
                   it = d.itemRefs.find(sym.value);
                 }


### PR DESCRIPTION
Without the cast, it results in the following compilation error: error: narrowing conversion of ‘(int64_t)sym.Symbol::value’ from ‘int64_t’ {aka ‘long int’} to ‘unsigned int’ [-Werror=narrowing]

This cast is similar to other ones in the file.