### PR TITLE
avif: Ignore still picture rules for Image Sequences

### DIFF
--- a/src/specs/avif/avif.cpp
+++ b/src/specs/avif/avif.cpp
@@ -103,6 +103,16 @@ void probeAV1ImageItem(Box const& root, IReport* out, uint32_t itemId, BoxReader
       return;
   }
 }
+
+bool isAvifImageSequence(Box const& root)
+{
+  // If the file contains the 'moov' box, then it is an AVIF image sequence.
+  for(auto& box: root.children)
+    if(box.fourcc == FOURCC("moov"))
+      return true;
+
+  return false;
+}
 } // namespace
 
 std::initializer_list<RuleDesc> rulesAvifGeneral =
@@ -221,6 +231,10 @@ std::initializer_list<RuleDesc> rulesAvifGeneral =
     "The AV1 Image Item Data should have its still_picture flag set to 1.",
     [] (Box const& root, IReport* out)
     {
+      // This rule does not apply for AVIF image sequences.
+      if(isAvifImageSequence(root))
+        return;
+
       auto const av1ImageItemIDs = findImageItems(root, FOURCC("av01"));
 
       for(auto itemId : av1ImageItemIDs)
@@ -243,6 +257,10 @@ std::initializer_list<RuleDesc> rulesAvifGeneral =
     "The AV1 Image Item Data should have its reduced_still_picture_header flag set to 1.",
     [] (Box const& root, IReport* out)
     {
+      // This rule does not apply for AVIF image sequences.
+      if(isAvifImageSequence(root))
+        return;
+
       auto const av1ImageItemIDs = findImageItems(root, FOURCC("av01"));
 
       for(auto itemId : av1ImageItemIDs)

--- a/tests/avif/invalid-avis-pict.ref
+++ b/tests/avif/invalid-avis-pict.ref
@@ -9,14 +9,12 @@ https://aomediacodec.github.io/av1-avif/
 [avif][Rule #1] Error: [ItemId=4] AV1 Sample shall be marked as sync (showFrame=0, keyFrame=0)
 [avif][Rule #2] Error: [ItemId=3] Expected 1 sequence Header OBU in Image Item Data but found 0
 [avif][Rule #2] Error: [ItemId=4] Expected 1 sequence Header OBU in Image Item Data but found 0
-[avif][Rule #4] Warning: [ItemId=3] reduced_still_picture_header flag set to 0
-[avif][Rule #4] Warning: [ItemId=4] reduced_still_picture_header flag set to 0
 [avif][Rule #10] Error: Primary item that is an AV1 image item found, but no track with 'pict' handler found.
 [avif][Rule #11] Error: The mono_chrome field in the Sequence Header OBU shall be set to 1 (item_ID=3)
 [avif][Rule #11] Error: The color_range field in the Sequence Header OBU shall be set to 1 (item_ID=3)
 
 ========================================
-[avif] 7 error(s), 2 warning(s).
+[avif] 7 error(s), 0 warning(s).
 ========================================
 
 ===== Involved rules descriptions:
@@ -26,9 +24,6 @@ The AV1 Image Item Data shall be identical to the content of an AV1 Sample marke
 
 [avif][Rule #2] Section 2.1
 The AV1 Image Item Data shall have exactly one Sequence Header OBU.
-
-[avif][Rule #4] Section 2.1
-The AV1 Image Item Data should have its reduced_still_picture_header flag set to 1.
 
 [avif][Rule #10] Section 3
 The track handler for an AV1 Image Sequence shall be 'pict'.

--- a/tests/avif/invalid-profile-track.ref
+++ b/tests/avif/invalid-profile-track.ref
@@ -6,26 +6,18 @@ Specification description: AVIF v1.0.0, 19 February 2019
 https://aomediacodec.github.io/av1-avif/
 
 [avif][Rule #1] Error: [ItemId=1] AV1 Sample shall be marked as sync (showFrame=0, keyFrame=0)
-[avif][Rule #3] Warning: [ItemId=1] still_picture flag set to 0
-[avif][Rule #4] Warning: [ItemId=1] reduced_still_picture_header flag set to 0
 [avif][Rule #10] Error: Track with 'pict' handler found, but no primary item that is an AV1 image item found.
 [avif][Rule #17] Error: Item ID=1 (image item): Baseline Profile requires AV1 Main Profile
 [avif][Rule #17] Error: Item ID=2 (image sequence): Baseline Profile requires AV1 Main Profile
 
 ========================================
-[avif] 4 error(s), 2 warning(s).
+[avif] 4 error(s), 0 warning(s).
 ========================================
 
 ===== Involved rules descriptions:
 
 [avif][Rule #1] Section 2.1
 The AV1 Image Item Data shall be identical to the content of an AV1 Sample marked as sync
-
-[avif][Rule #3] Section 2.1
-The AV1 Image Item Data should have its still_picture flag set to 1.
-
-[avif][Rule #4] Section 2.1
-The AV1 Image Item Data should have its reduced_still_picture_header flag set to 1.
 
 [avif][Rule #10] Section 3
 The track handler for an AV1 Image Sequence shall be 'pict'.


### PR DESCRIPTION
This was updated in the AVIF specification version 1.1.0: https://github.com/AOMediaCodec/av1-avif/pull/138