### PR TITLE
Align the rules from the latest AV1 HDR10+ spec

### DIFF
--- a/scripts/hdr10plusrules.py
+++ b/scripts/hdr10plusrules.py
@@ -1,13 +1,16 @@
 import argparse
+import urllib.request
 
 from bs4 import BeautifulSoup
+
+SPEC_URL = "https://aomediacodec.github.io/av1-hdr10plus/"
 
 src_file = "../src/specs/av1_hdr10plus/av1_hdr10plus.cpp"
 
 parser = argparse.ArgumentParser(
     description="Check if all rules from the HDR10+ spec are implemented.")
 
-parser.add_argument("-i", "--input", help="Spec HTML file.", required=True)
+parser.add_argument("-i", "--input", help="Spec HTML file.")
 parser.add_argument(
     "--dump", help="Dump code snippet based on asserts in HTML.", action="store_true")
 args = parser.parse_args()
@@ -15,8 +18,12 @@ args = parser.parse_args()
 with open(src_file, "r", encoding="utf-8") as src_f:
     src = src_f.read()
 
-with open(args.input, "r", encoding="utf-8") as f:
-    soup = BeautifulSoup(f, features='lxml')
+if args.input is not None:
+    with open(args.input, "r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, features='lxml')
+else:
+    html_string = urllib.request.urlopen(SPEC_URL).read()
+    soup = BeautifulSoup(html_string, features='lxml')
 
 assert_spans = soup.find_all(
     "span", {"id": lambda L: L and L.startswith("assert-")})

--- a/scripts/hdr10plusrules.py
+++ b/scripts/hdr10plusrules.py
@@ -1,0 +1,40 @@
+import argparse
+
+from bs4 import BeautifulSoup
+
+src_file = "../src/specs/av1_hdr10plus/av1_hdr10plus.cpp"
+
+parser = argparse.ArgumentParser(
+    description="Check if all rules from the HDR10+ spec are implemented.")
+
+parser.add_argument("-i", "--input", help="Spec HTML file.", required=True)
+parser.add_argument(
+    "--dump", help="Dump code snippet based on asserts in HTML.", action="store_true")
+args = parser.parse_args()
+
+with open(src_file, "r", encoding="utf-8") as src_f:
+    src = src_f.read()
+
+with open(args.input, "r", encoding="utf-8") as f:
+    soup = BeautifulSoup(f, features='lxml')
+
+assert_spans = soup.find_all(
+    "span", {"id": lambda L: L and L.startswith("assert-")})
+
+rules = []
+for assert_span in assert_spans:
+    rules.append({"id": assert_span.get("id"),
+                 "description": assert_span.text.replace('"', ''), "implemented": assert_span.get("id") in src})
+
+if args.dump:
+    for rule in rules:
+        print(
+            f'{{\n  "{rule["description"]}",\n  "{rule["id"]}",\n  [](Box const & root, IReport * out)\n  {{\n  }}\n}},')
+else:
+    impl = [r for r in rules if r["implemented"]]
+    nimpl = [r for r in rules if not r["implemented"]]
+
+    print(f'{len(impl)} from {len(rules)} rules implemented.')
+    print('List of rules to be implemented:')
+    for rule in nimpl:
+        print(f'\t"{rule["id"]}": "{rule["description"]}"')

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -547,8 +547,7 @@ const SpecDesc specAv1Hdr10plus =
       {
         if(!isIsobmff(root))
           return;
-        
-        // TODO: implement me
+        // This should already be implemented in here by evaluating all other rules. We keep it in here to satisfy the python script.
       }
     },
     {
@@ -558,8 +557,7 @@ const SpecDesc specAv1Hdr10plus =
       {
         if(!isIsobmff(root))
           return;
-        
-        // TODO: Is this also in scope of CW?
+        // This is out of scope for ComplianceWarden. We keep it in here to satisfy the python script.
       }
     },
     {
@@ -569,8 +567,7 @@ const SpecDesc specAv1Hdr10plus =
       {
         if(!isIsobmff(root))
           return;
-        
-        // TODO: Is this also in scope of CW?
+        // This is out of scope for ComplianceWarden. We keep it in here to satisfy the python script.
       }
     },
   },

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -33,28 +33,28 @@ const SpecDesc specAv1Hdr10plus =
   "https://aomediacodec.github.io/av1-hdr10plus/",
   { "isobmff" },
   {
-    // { // This rule does seems to be from the older version of the spec?
-    //   "An AV1 stream shall contain at least one OBU",
-    //   [] (Box const& root, IReport* out)
-    //   {
-    //     BoxReader br;
-    //     br.br = getData(root, out);
+    { // This rule does not exist in the AV1 HDR10+ spec. Should it be in some dependency?
+      "An AV1 stream shall contain at least one OBU",
+      [] (Box const& root, IReport* out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
-    //     if(br.br.size < 2)
-    //     {
-    //       out->error("Not enough bytes(=%llu) to contain an OBU", br.br.size);
-    //       return;
-    //     }
+        if(br.br.size < 2)
+        {
+          out->error("Not enough bytes(=%llu) to contain an OBU", br.br.size);
+          return;
+        }
 
-    //     out->covered();
+        out->covered();
 
-    //     Av1State stateUnused;
-    //     auto obuType = parseAv1Obus(&br, stateUnused, false);
+        Av1State stateUnused;
+        auto obuType = parseAv1Obus(&br, stateUnused, false);
 
-    //     if(!obuType)
-    //       out->error("An AV1 stream shall contain at least one OBU but first OBU could not be parsed");
-    //   }
-    // },
+        if(!obuType)
+          out->error("An AV1 stream shall contain at least one OBU but first OBU could not be parsed");
+      }
+    },
     {
       "Section 2.1\n"
       "An HDR10+ Metadata OBU is defined as HDR10+ Metadata carried in a Metadata OBU. The metadata_type of such Metadata OBU is set to METADATA_TYPE_ITUT_T35 and the itu_t_t35_country_code of the corresponding Metadata ITUT T35 element is set to 0xB5.\n"

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -56,6 +56,7 @@ const SpecDesc specAv1Hdr10plus =
     //   }
     // },
     {
+      "Section 2.1\n"
       "An HDR10+ Metadata OBU is defined as HDR10+ Metadata carried in a Metadata OBU. The metadata_type of such Metadata OBU is set to METADATA_TYPE_ITUT_T35 and the itu_t_t35_country_code of the corresponding Metadata ITUT T35 element is set to 0xB5.\n"
       "The remaining syntax element of Metadata ITUT T35, itu_t_t35_payload_bytes, is interpreted using the syntax defined in Annex S of [CTA-861], starting with the itu_t_t35_terminal_provider_code, and the semantics defined in [ST-2094-40].\n"
       "According to the definition of the HDR10+ Metadata, the first 6 bytes of the itu_t_t35_payload_bytes of the HDR10+ Metadata OBU are set as follows:\n"
@@ -96,7 +97,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "color_primaries = 9",
       "assert-2d0cc174",
       [] (Box const& root, IReport* out)
@@ -123,7 +124,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "transfer_characteristics = 16",
       "assert-0931ac52",
       [] (Box const& root, IReport* out)
@@ -150,7 +151,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "matrix_coefficients = 9",
       "assert-19a71368",
       [] (Box const& root, IReport* out)
@@ -177,7 +178,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "color_range should be set to 0",
       "assert-02249407",
       [] (Box const& root, IReport* out)
@@ -204,7 +205,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "subsampling_x and subsampling_y should be set to 0",
       "assert-5230c330",
       [](Box const & root, IReport * out)
@@ -235,7 +236,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "mono_chrome should be set to 0",
       "assert-4217c4a7",
       [](Box const & root, IReport * out)
@@ -262,7 +263,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.1\n",
+      "Section 2.2.1\n"
       "chroma_sample_position should be set to 2",
       "assert-5b56cde2",
       [] (Box const& root, IReport* out)
@@ -289,7 +290,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.2\n",
+      "Section 2.2.2\n"
       "for each frame with show_frame = 1 or show_existing_frame = 1, there shall be one and only one HDR10+ metadata OBU preceding the Frame Header OBU for this frame and located after the last OBU of the previous frame (if any) or after the Sequence Header OBU (if any) or after the start of the temporal unit",
       "assert-45af0987",
       [] (Box const& root, IReport* out)
@@ -467,7 +468,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n",
+      "Section 3.2\n"
       "AV1 Metadata sample group defined in [AV1-ISOBMFF] shall not be used.",
       "assert-398f68cd",
       [] (Box const& root, IReport* /*out*/)
@@ -480,7 +481,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n",
+      "Section 3.2\n"
       "HDR10 Static Metadata and HDR10+ Metadata OBUs are unprotected",
       "assert-d451561e",
       [] (Box const& root, IReport* /*out*/)
@@ -494,7 +495,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n",
+      "Section 3.2\n"
       "An ISOBMFF file or CMAF AV1 track as defined in [AV1-ISOBMFF] that also conforms to this specification (i.e. that contains HDR10+ metadata OBUs and complies to the constraints from this specification) should use the brand cdm4 defined in [CTA-5001] in addition to the brand av01",
       "assert-c56194aa",
       [] (Box const& root, IReport* out)
@@ -519,7 +520,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.2\n",
+      "Section 2.2.2\n"
       "HDR10+ Metadata OBUs are not provided when show_frame = 0",
       "assert-a575dc54",
       [] (Box const& root, IReport* /*out*/)
@@ -531,7 +532,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.2\n",
+      "Section 2.2.2\n"
       "For non-layered streams, there is only one HDR10+ Metadata OBU per temporal unit",
       "assert-797eb19e",
       [] (Box const& root, IReport* /*out*/)
@@ -543,7 +544,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.1\n",
+      "Section 3.1\n"
       "For formats that use the AV1CodecConfigurationRecord when storing [AV1] bitstreams (e.g. ISOBMFF and MPEG-2 TS), HDR10+ Metadata OBUs shall not be present in the configOBUs field of the AV1CodecConfigurationRecord",
       "assert-aa071f33",
       [] (Box const& root, IReport* /*out*/)
@@ -555,7 +556,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n",
+      "Section 3.2\n"
       "If the brand cdm4 is used in conjunction with [AV1] bitstreams, the constraints defined in this specification shall be respected",
       "assert-3a8897d6",
       [] (Box const& root, IReport* /*out*/)
@@ -566,7 +567,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.3\n",
+      "Section 3.3\n"
       "[DASH] content following [DASH-IOP] should include a Supplemental Descriptor with @schemeIdUri set to http://dashif.org/metadata/hdr and @value set to SMPTE2094-40 in manifest files",
       "assert-622a560f",
       [] (Box const& root, IReport* /*out*/)
@@ -577,7 +578,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.3\n",
+      "Section 3.3\n"
       "The value of the Codecs Parameter String for [AV1] bitstreams that is used when using HTTP streaming technologies shall remain unchanged when HDR10+ Metadata OBUs are included in the [AV1] stream",
       "assert-91363c5f",
       [] (Box const& root, IReport* /*out*/)

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -96,6 +96,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "color_primaries = 9",
       "assert-2d0cc174",
       [] (Box const& root, IReport* out)
@@ -122,6 +123,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "transfer_characteristics = 16",
       "assert-0931ac52",
       [] (Box const& root, IReport* out)
@@ -148,6 +150,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "matrix_coefficients = 9",
       "assert-19a71368",
       [] (Box const& root, IReport* out)
@@ -174,6 +177,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "color_range should be set to 0",
       "assert-02249407",
       [] (Box const& root, IReport* out)
@@ -200,6 +204,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "subsampling_x and subsampling_y should be set to 0",
       "assert-5230c330",
       [](Box const & root, IReport * out)
@@ -230,6 +235,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "mono_chrome should be set to 0",
       "assert-4217c4a7",
       [](Box const & root, IReport * out)
@@ -256,6 +262,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.1\n",
       "chroma_sample_position should be set to 2",
       "assert-5b56cde2",
       [] (Box const& root, IReport* out)
@@ -282,6 +289,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.2\n",
       "for each frame with show_frame = 1 or show_existing_frame = 1, there shall be one and only one HDR10+ metadata OBU preceding the Frame Header OBU for this frame and located after the last OBU of the previous frame (if any) or after the Sequence Header OBU (if any) or after the start of the temporal unit",
       "assert-45af0987",
       [] (Box const& root, IReport* out)
@@ -459,6 +467,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.2\n",
       "AV1 Metadata sample group defined in [AV1-ISOBMFF] shall not be used.",
       "assert-398f68cd",
       [] (Box const& root, IReport* /*out*/)
@@ -471,6 +480,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.2\n",
       "HDR10 Static Metadata and HDR10+ Metadata OBUs are unprotected",
       "assert-d451561e",
       [] (Box const& root, IReport* /*out*/)
@@ -484,6 +494,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.2\n",
       "An ISOBMFF file or CMAF AV1 track as defined in [AV1-ISOBMFF] that also conforms to this specification (i.e. that contains HDR10+ metadata OBUs and complies to the constraints from this specification) should use the brand cdm4 defined in [CTA-5001] in addition to the brand av01",
       "assert-c56194aa",
       [] (Box const& root, IReport* out)
@@ -508,6 +519,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.2\n",
       "HDR10+ Metadata OBUs are not provided when show_frame = 0",
       "assert-a575dc54",
       [] (Box const& root, IReport* /*out*/)
@@ -519,6 +531,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.2\n",
       "For non-layered streams, there is only one HDR10+ Metadata OBU per temporal unit",
       "assert-797eb19e",
       [] (Box const& root, IReport* /*out*/)
@@ -530,6 +543,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.1\n",
       "For formats that use the AV1CodecConfigurationRecord when storing [AV1] bitstreams (e.g. ISOBMFF and MPEG-2 TS), HDR10+ Metadata OBUs shall not be present in the configOBUs field of the AV1CodecConfigurationRecord",
       "assert-aa071f33",
       [] (Box const& root, IReport* /*out*/)
@@ -541,6 +555,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.2\n",
       "If the brand cdm4 is used in conjunction with [AV1] bitstreams, the constraints defined in this specification shall be respected",
       "assert-3a8897d6",
       [] (Box const& root, IReport* /*out*/)
@@ -551,6 +566,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.3\n",
       "[DASH] content following [DASH-IOP] should include a Supplemental Descriptor with @schemeIdUri set to http://dashif.org/metadata/hdr and @value set to SMPTE2094-40 in manifest files",
       "assert-622a560f",
       [] (Box const& root, IReport* /*out*/)
@@ -561,6 +577,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 3.3\n",
       "The value of the Codecs Parameter String for [AV1] bitstreams that is used when using HTTP streaming technologies shall remain unchanged when HDR10+ Metadata OBUs are included in the [AV1] stream",
       "assert-91363c5f",
       [] (Box const& root, IReport* /*out*/)

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -468,6 +468,42 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
+      "Section 2.2.2\n"
+      "HDR10+ Metadata OBUs are not provided when show_frame = 0",
+      "assert-a575dc54",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "Section 2.2.2\n"
+      "For non-layered streams, there is only one HDR10+ Metadata OBU per temporal unit",
+      "assert-797eb19e",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "Section 3.1\n"
+      "For formats that use the AV1CodecConfigurationRecord when storing [AV1] bitstreams (e.g. ISOBMFF and MPEG-2 TS), HDR10+ Metadata OBUs shall not be present in the configOBUs field of the AV1CodecConfigurationRecord",
+      "assert-aa071f33",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
       "Section 3.2\n"
       "AV1 Metadata sample group defined in [AV1-ISOBMFF] shall not be used.",
       "assert-398f68cd",
@@ -517,42 +553,6 @@ const SpecDesc specAv1Hdr10plus =
 
           out->covered();
         }
-      }
-    },
-    {
-      "Section 2.2.2\n"
-      "HDR10+ Metadata OBUs are not provided when show_frame = 0",
-      "assert-a575dc54",
-      [] (Box const& root, IReport* /*out*/)
-      {
-        if(!isIsobmff(root))
-          return;
-        
-        // TODO: implement me
-      }
-    },
-    {
-      "Section 2.2.2\n"
-      "For non-layered streams, there is only one HDR10+ Metadata OBU per temporal unit",
-      "assert-797eb19e",
-      [] (Box const& root, IReport* /*out*/)
-      {
-        if(!isIsobmff(root))
-          return;
-        
-        // TODO: implement me
-      }
-    },
-    {
-      "Section 3.1\n"
-      "For formats that use the AV1CodecConfigurationRecord when storing [AV1] bitstreams (e.g. ISOBMFF and MPEG-2 TS), HDR10+ Metadata OBUs shall not be present in the configOBUs field of the AV1CodecConfigurationRecord",
-      "assert-aa071f33",
-      [] (Box const& root, IReport* /*out*/)
-      {
-        if(!isIsobmff(root))
-          return;
-        
-        // TODO: implement me
       }
     },
     {

--- a/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
+++ b/src/specs/av1_hdr10plus/av1_hdr10plus.cpp
@@ -33,35 +33,36 @@ const SpecDesc specAv1Hdr10plus =
   "https://aomediacodec.github.io/av1-hdr10plus/",
   { "isobmff" },
   {
+    // { // This rule does seems to be from the older version of the spec?
+    //   "An AV1 stream shall contain at least one OBU",
+    //   [] (Box const& root, IReport* out)
+    //   {
+    //     BoxReader br;
+    //     br.br = getData(root, out);
+
+    //     if(br.br.size < 2)
+    //     {
+    //       out->error("Not enough bytes(=%llu) to contain an OBU", br.br.size);
+    //       return;
+    //     }
+
+    //     out->covered();
+
+    //     Av1State stateUnused;
+    //     auto obuType = parseAv1Obus(&br, stateUnused, false);
+
+    //     if(!obuType)
+    //       out->error("An AV1 stream shall contain at least one OBU but first OBU could not be parsed");
+    //   }
+    // },
     {
-      "Section 2.1\n"
-      "An AV1 stream shall contain at least one OBU",
-      [] (Box const& root, IReport* out)
-      {
-        BoxReader br;
-        br.br = getData(root, out);
-
-        if(br.br.size < 2)
-        {
-          out->error("Not enough bytes(=%llu) to contain an OBU", br.br.size);
-          return;
-        }
-
-        out->covered();
-
-        Av1State stateUnused;
-        auto obuType = parseAv1Obus(&br, stateUnused, false);
-
-        if(!obuType)
-          out->error("An AV1 stream shall contain at least one OBU but first OBU could not be parsed");
-      }
-    },
-    {
-      "Section 2.1\n"
-      "Each HDR10+ OBU includes an ITU-T T.35 identifier with:\n"
-      " - itu_t_t35_country_code set as 0xB5\n"
-      " - itu_t_t35_terminal_provider_code set as 0x003C\n"
-      " - itu_t_t35_terminal_provider_oriented_code set as 0x0001",
+      "An HDR10+ Metadata OBU is defined as HDR10+ Metadata carried in a Metadata OBU. The metadata_type of such Metadata OBU is set to METADATA_TYPE_ITUT_T35 and the itu_t_t35_country_code of the corresponding Metadata ITUT T35 element is set to 0xB5.\n"
+      "The remaining syntax element of Metadata ITUT T35, itu_t_t35_payload_bytes, is interpreted using the syntax defined in Annex S of [CTA-861], starting with the itu_t_t35_terminal_provider_code, and the semantics defined in [ST-2094-40].\n"
+      "According to the definition of the HDR10+ Metadata, the first 6 bytes of the itu_t_t35_payload_bytes of the HDR10+ Metadata OBU are set as follows:\n"
+      " - 0x003C, which corresponds to itu_t_t35_terminal_provider_code from Annex S of [CTA-861]\n"
+      " - 0x0001, which corresponds to itu_t_t35_terminal_provider_oriented_code from Annex S of [CTA-861]\n"
+      " - 0x4, which corresponds to application_identifier from Annex S of [CTA-861]\n"
+      " - 0x1, which corresponds to application_mode from Annex S of [CTA-861]",
       [] (Box const& root, IReport* out)
       {
         BoxReader br;
@@ -90,20 +91,13 @@ const SpecDesc specAv1Hdr10plus =
           if(!strcmp(sym.name, "itu_t_t35_terminal_provider_oriented_code"))
             if(sym.value != 0x0001)
               out->error("itu_t_t35_terminal_provider_oriented_code shall be set as 0x0001, found 0x%04X", sym.value);
+          // TODO: also check application_identifier and application_mode
         }
       }
     },
     {
-      "Section 2.2.1\n"
-      "Streams shall use the following values for the AV1 color_config:\n"
-      " - color_primaries = 9 ([BT-2020])\n"
-      " - transfer_characteristics = 16 ([SMPTE-ST-2084] / [BT-2100])\n"
-      " - matrix_coefficients = 9 ([BT-2020])\n"
-      "Additionally, the following recommendations apply:\n"
-      " - VideoFullRangeFlag should be set to 0\n"
-      " - subsampling_x and subsampling_y should be set to 0\n"
-      " - mono_chrome should be 0\n"
-      " - chroma_sample_position should be set to 2",
+      "color_primaries = 9",
+      "assert-2d0cc174",
       [] (Box const& root, IReport* out)
       {
         BoxReader br;
@@ -124,19 +118,107 @@ const SpecDesc specAv1Hdr10plus =
           if(!strcmp(sym.name, "color_primaries"))
             if(sym.value != 9)
               out->error("color_primaries shall be set as 9 ([BT-2020]), found %d", sym.value);
+        }
+      }
+    },
+    {
+      "transfer_characteristics = 16",
+      "assert-0931ac52",
+      [] (Box const& root, IReport* out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "transfer_characteristics"))
             if(sym.value != 16)
               out->error("transfer_characteristics shall be set as 16 ([SMPTE-ST-2084] / [BT-2100]), found %d", sym.value);
+        }
+      }
+    },
+    {
+      "matrix_coefficients = 9",
+      "assert-19a71368",
+      [] (Box const& root, IReport* out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "matrix_coefficients"))
             if(sym.value != 9)
               out->error("matrix_coefficients shall be set as 9 ([BT-2020]), found %d", sym.value);
+        }
+      }
+    },
+    {
+      "color_range should be set to 0",
+      "assert-02249407",
+      [] (Box const& root, IReport* out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "color_range"))
             if(sym.value != 0)
-              out->warning("VideoFullRangeFlag should be set as 0, found %d", sym.value);
+              out->warning("color_range should be set as 0, found %d", sym.value);
+        }
+      }
+    },
+    {
+      "subsampling_x and subsampling_y should be set to 0",
+      "assert-5230c330",
+      [](Box const & root, IReport * out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "subsampling_x"))
             if(sym.value != 0)
               out->warning("subsampling_x should be set as 0, found %d", sym.value);
@@ -144,11 +226,55 @@ const SpecDesc specAv1Hdr10plus =
           if(!strcmp(sym.name, "subsampling_y"))
             if(sym.value != 0)
               out->warning("subsampling_y should be set as 0, found %d", sym.value);
+        }
+      }
+    },
+    {
+      "mono_chrome should be set to 0",
+      "assert-4217c4a7",
+      [](Box const & root, IReport * out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "mono_chrome"))
             if(sym.value != 0)
               out->warning("mono_chrome should be set as 0, found %d", sym.value);
+        }
+      }
+    },
+    {
+      "chroma_sample_position should be set to 2",
+      "assert-5b56cde2",
+      [] (Box const& root, IReport* out)
+      {
+        BoxReader br;
+        br.br = getData(root, out);
 
+        if(br.br.size < 2)
+          return;
+
+        while(!br.empty())
+        {
+          Av1State stateUnused;
+          parseAv1Obus(&br, stateUnused, false);
+          out->covered();
+        }
+
+        for(auto& sym : br.myBox.syms)
+        {
           if(!strcmp(sym.name, "chroma_sample_position"))
             if(sym.value != 2)
               out->warning("chroma_sample_position should be set as 2, found %d", sym.value);
@@ -156,12 +282,7 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 2.2.2\n"
-      "for each frame with show_frame=1 or show_existing_frame=1, there shall be one\n"
-      "and only one HDR10+ metadata OBU preceding the frame header for this frame and\n"
-      "located after the last OBU of the previous frame (if any) or after the\n"
-      "Sequence Header (if any) or after the start of the temporal unit (e.g. after the\n"
-      "temporal delimiter, for storage formats where temporal delimiters are preserved).",
+      "for each frame with show_frame = 1 or show_existing_frame = 1, there shall be one and only one HDR10+ metadata OBU preceding the Frame Header OBU for this frame and located after the last OBU of the previous frame (if any) or after the Sequence Header OBU (if any) or after the start of the temporal unit",
       "assert-45af0987",
       [] (Box const& root, IReport* out)
       {
@@ -338,8 +459,8 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n"
       "AV1 Metadata sample group defined in [AV1-ISOBMFF] shall not be used.",
+      "assert-398f68cd",
       [] (Box const& root, IReport* /*out*/)
       {
         if(!isIsobmff(root))
@@ -350,8 +471,8 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n"
-      "This specification requires that HDR10 Static Metadata [...] be unprotected",
+      "HDR10 Static Metadata and HDR10+ Metadata OBUs are unprotected",
+      "assert-d451561e",
       [] (Box const& root, IReport* /*out*/)
       {
         if(!isIsobmff(root))
@@ -363,22 +484,8 @@ const SpecDesc specAv1Hdr10plus =
       }
     },
     {
-      "Section 3.2\n"
-      "This specification requires that [...] HDR10+ Metadata OBUs be unprotected ",
-      [] (Box const& root, IReport* /*out*/)
-      {
-        if(!isIsobmff(root))
-          return;
-
-        // TODO: encryption not supported in ISOBMFF yet
-        // out->covered();
-      }
-    },
-    {
-      "Section 3.3\n"
-      "An ISOBMFF file or CMAF AV1 track as defined in [AV1-ISOBMFF] that also conforms\n"
-      "to this specification should use the brand cdm4\n"
-      "defined in [CTA-5001] in addition to the brand av01.",
+      "An ISOBMFF file or CMAF AV1 track as defined in [AV1-ISOBMFF] that also conforms to this specification (i.e. that contains HDR10+ metadata OBUs and complies to the constraints from this specification) should use the brand cdm4 defined in [CTA-5001] in addition to the brand av01",
+      "assert-c56194aa",
       [] (Box const& root, IReport* out)
       {
         if(!isIsobmff(root))
@@ -398,6 +505,72 @@ const SpecDesc specAv1Hdr10plus =
 
           out->covered();
         }
+      }
+    },
+    {
+      "HDR10+ Metadata OBUs are not provided when show_frame = 0",
+      "assert-a575dc54",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "For non-layered streams, there is only one HDR10+ Metadata OBU per temporal unit",
+      "assert-797eb19e",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "For formats that use the AV1CodecConfigurationRecord when storing [AV1] bitstreams (e.g. ISOBMFF and MPEG-2 TS), HDR10+ Metadata OBUs shall not be present in the configOBUs field of the AV1CodecConfigurationRecord",
+      "assert-aa071f33",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "If the brand cdm4 is used in conjunction with [AV1] bitstreams, the constraints defined in this specification shall be respected",
+      "assert-3a8897d6",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: implement me
+      }
+    },
+    {
+      "[DASH] content following [DASH-IOP] should include a Supplemental Descriptor with @schemeIdUri set to http://dashif.org/metadata/hdr and @value set to SMPTE2094-40 in manifest files",
+      "assert-622a560f",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: Is this also in scope of CW?
+      }
+    },
+    {
+      "The value of the Codecs Parameter String for [AV1] bitstreams that is used when using HTTP streaming technologies shall remain unchanged when HDR10+ Metadata OBUs are included in the [AV1] stream",
+      "assert-91363c5f",
+      [] (Box const& root, IReport* /*out*/)
+      {
+        if(!isIsobmff(root))
+          return;
+        
+        // TODO: Is this also in scope of CW?
       }
     },
   },


### PR DESCRIPTION
Proposed starting point for the https://github.com/AOMediaCodec/av1-hdr10plus/pull/32 where every rule from the spec is added (including the `assert-id`).