### PR TITLE
test: do not expand CXX unless set

### DIFF
--- a/check
+++ b/check
@@ -10,7 +10,12 @@ else
 fi
 
 ./scripts/reformat.sh
-CXX=$CXX make -j$CORES
+if [ -z ${CXX+x} ]; then
+  make -j$CORES
+else
+  CXX=$CXX make -j$CORES
+fi
+  
 ./tests/run $BIN
 
 lines=$(find $BIN -name "*.lines" | xargs cat | awk '{s+=$1} END {printf "%d\n", (s/1000)}')


### PR DESCRIPTION
When `CXX` env var is not yet, the check script fails on Ubuntu with:

```
$ ./check 
Reformatting...
./check: line 13: CXX: unbound variable
```

This checks it is bound before expanding.