### PR TITLE
Recognize infe image item 'unci'

### DIFF
--- a/src/utils/common_boxes.cpp
+++ b/src/utils/common_boxes.cpp
@@ -742,7 +742,8 @@ void parseChildren(IReader *br)
 
 std::vector<uint32_t> visualSampleEntryFourccs = { FOURCC("avc1"), FOURCC("avc2"), FOURCC("avc3"),
                                                    FOURCC("avc4"), FOURCC("hev1"), FOURCC("hev2"),
-                                                   FOURCC("hvc1"), FOURCC("hvc2"), FOURCC("av01") };
+                                                   FOURCC("hvc1"), FOURCC("hvc2"), FOURCC("av01"),
+                                                   FOURCC("unci") };
 
 bool isVisualSampleEntry(uint32_t fourcc)
 {


### PR DESCRIPTION
ISO/IEC 23001-17 states that an uncompressed infe image shall have an item_type of 'unci'.

Without this detection, the following error occurs:
[heif][Rule #14] Error: primary item (Item_ID=3) is not coded image or a derived image item (found item_type="unci")