### PR TITLE
Missing Spec Name Error Message

### DIFF
--- a/src/app/cw.cpp
+++ b/src/app/cw.cpp
@@ -152,7 +152,14 @@ int main(int argc, const char *argv[])
     return 0;
   }
 
-  if(specName.empty() || urls.size() != 1) {
+  if(specName.empty()) {
+    fprintVersion(stderr);
+    opt.printHelp(stderr);
+    fprintf(stderr, ">>>>> Specification name not provided. <<<<<\n\n");
+    return 1;
+  }
+
+  if(urls.size() != 1) {
     fprintVersion(stderr);
     opt.printHelp(stderr);
     fprintf(stderr, ">>>>> Expected 1 input file, got %zu. See usage above. <<<<<\n\n", urls.size());


### PR DESCRIPTION
If the user doesn't provide a spec name, then CW gives a misleading error:

`>>>>> Expected 1 input file, got 1. See usage above. <<<<<`