### PR TITLE
Parse uuid Box

### DIFF
--- a/src/core/common_boxes.cpp
+++ b/src/core/common_boxes.cpp
@@ -2,6 +2,7 @@
 #include "common_boxes.h"
 
 #include <cassert>
+#include <cstring>
 #include <vector>
 
 #include "fourcc.h"
@@ -915,6 +916,22 @@ void parseTrun(IReader *br)
   }
 }
 
+void parseUuid(IReader *br)
+{
+  uint8_t extended_type[16];
+  for(int i = 0; i < 16; ++i)
+    extended_type[i] = br->sym("extended_type", 8);
+
+  ParseBoxFunc *func = getUuidParseFunction(extended_type);
+  func(br);
+}
+
+void parseItemContentIDProperty(IReader *br)
+{
+  while(!br->empty())
+    br->sym("ItemContentID", 8);
+}
+
 void parseChildren(IReader *br)
 {
   while(!br->empty())
@@ -1049,10 +1066,21 @@ ParseBoxFunc *getParseFunction(uint32_t fourcc)
     return &parseTrex;
   case FOURCC("trun"):
     return &parseTrun;
+  case FOURCC("uuid"):
+    return &parseUuid;
   }
 
   if(isVisualSampleEntry(fourcc))
     return &parseVisualSampleEntry;
 
   return &parseRaw;
+}
+
+ParseBoxFunc *getUuidParseFunction(const uint8_t (&extended_type)[16])
+{
+  if(std::memcmp(extended_type, ItemContentIDProperty, 16) == 0) {
+    return &parseItemContentIDProperty;
+  } else {
+    return &parseRaw;
+  }
 }

--- a/src/core/common_boxes.h
+++ b/src/core/common_boxes.h
@@ -3,3 +3,9 @@
 #include "box_reader.h"
 
 ParseBoxFunc *getParseFunction(uint32_t fourcc);
+
+ParseBoxFunc *getUuidParseFunction(const uint8_t (&extended_type)[16]);
+
+static const uint8_t ItemContentIDProperty[16] = {
+  0x26, 0x1e, 0xf3, 0x74, 0x1d, 0x97, 0x5b, 0xba, 0xac, 0xbd, 0x9d, 0x2c, 0x8e, 0xa7, 0x35, 0x22,
+};


### PR DESCRIPTION
The uuid box defines a 16-byte `extended_type` variable and allows for users to define their own custom boxes.

This PR reads the `ItemContentIDProperty` uuid box defined in the GIMI spec. I put it in common_boxes.cpp, but it's a box that's not very common, so perhaps there's a better place for it.

ISO/IEC 14496-12 Section 4.2.2
```C
aligned(8) class BoxHeader (
    unsigned int(32) boxtype,
    optional unsigned int(8)[16] extended_type) {
  unsigned int(32) size;
  unsigned int(32) type = boxtype;
  if (size==1) {
    unsigned int(64) largesize;
  } else if (size==0) {
    // box extends to end of file
  }
  if (boxtype=='uuid') {
    unsigned int(8)[16] usertype = extended_type;
  }
}
```