### PR TITLE
Print Error Message for Bad AVC Profile

### DIFF
--- a/src/core/common_boxes.cpp
+++ b/src/core/common_boxes.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <stdexcept>
 #include <vector>
 
 #include "fourcc.h"
@@ -227,6 +228,11 @@ void parseAvcC(IReader *br)
   }
 
   if(AVCProfileIndication != 66 && AVCProfileIndication != 77 && AVCProfileIndication != 88) {
+    if(br->empty()) {
+      // Call fprintf() because catch(...) will not print the error message
+      fprintf(stderr, "AVCProfileIndiciation is not 66, 77, or 88, so profile code is expected, but missing.\n");
+      throw std::runtime_error("AVCProfileIndiciation is not 66, 77, or 88, so profile code is expected, but missing.");
+    }
     br->sym("reserved9", 6);
     br->sym("chroma_format", 2);
     br->sym("reserved10", 5);

--- a/src/core/common_boxes.cpp
+++ b/src/core/common_boxes.cpp
@@ -230,8 +230,8 @@ void parseAvcC(IReader *br)
   if(AVCProfileIndication != 66 && AVCProfileIndication != 77 && AVCProfileIndication != 88) {
     if(br->empty()) {
       // Call fprintf() because catch(...) will not print the error message
-      fprintf(stderr, "AVCProfileIndiciation is not 66, 77, or 88, so profile code is expected, but missing.\n");
-      throw std::runtime_error("AVCProfileIndiciation is not 66, 77, or 88, so profile code is expected, but missing.");
+      fprintf(stderr, "AVCProfileIndication is not 66, 77, or 88, so profile code is expected, but missing.\n");
+      throw std::runtime_error("AVCProfileIndication is not 66, 77, or 88, so profile code is expected, but missing.");
     }
     br->sym("reserved9", 6);
     br->sym("chroma_format", 2);


### PR DESCRIPTION
A common error for the `avcC` box is providing profile values despite `AVCProfileIndication` variable saying there shouldn't be.

This PR prints an additional message informing the user of the issue.